### PR TITLE
fix: make tracklist height shrink by default

### DIFF
--- a/src/Components/EpisodeList.tsx
+++ b/src/Components/EpisodeList.tsx
@@ -52,7 +52,7 @@ function EpisodeList({ episodes }: Readonly<EpisodeListProps>) {
         <h1 className={`text-xl`}>{t("episodes")}</h1>
         <div
           ref={episodeListRef}
-          className={`overflow-auto w-full h-full border rounded border-grey-200`}
+          className={`overflow-auto w-full max-h-full border rounded border-grey-200`}
         >
           <div
             style={{

--- a/src/Components/TrackList.tsx
+++ b/src/Components/TrackList.tsx
@@ -53,7 +53,7 @@ function TrackList({ tracks, includeAdd = false }: Readonly<TrackListProps>) {
         <h1 className={`text-xl`}>{t("tracks")}</h1>
         <div
           ref={trackListRef}
-          className="overflow-auto w-full h-full border rounded border-grey-200"
+          className="overflow-auto w-full max-h-full border rounded border-grey-200"
         >
           <div
             style={{


### PR DESCRIPTION
This should shrink if less than the full screen size is used, but should grow up to the 100% size